### PR TITLE
merger resolving: Added relabelMergers() function to refine segmentation on Ilastik

### DIFF
--- a/hytra/core/ilastikmergerresolver.py
+++ b/hytra/core/ilastikmergerresolver.py
@@ -20,7 +20,6 @@ class IlastikMergerResolver(hytra.core.mergerresolver.MergerResolver):
         self.result = hypothesesGraph.getSolutionDictionary()
         self.hypothesesGraph = hypothesesGraph
         self.labelVolume = labelVolume
-        self.relabeledVolume = np.zeros(labelVolume.shape, dtype=np.uint32)
     
     def _readLabelImage(self, timeframe):
         '''
@@ -28,16 +27,13 @@ class IlastikMergerResolver(hytra.core.mergerresolver.MergerResolver):
         '''
         return self.labelVolume[timeframe, ..., 0]
     
-    def _exportRefinedSegmentation(self, labelImages):
+    def _exportRefinedSegmentation(self, timesteps):
         """
-        Store the resulting label images, if needed.
-
-        `labelImages` is a dictionary with str(timestep) as keys. 
+        nothing to be done here, ilastik requests these images lazily 
         """
-        for t, image in labelImages.iteritems():
-            self.relabeledVolume[int(t), ..., 0] = image
+        pass
 
-    def _computeObjectFeatures(self, labelImages):
+    def _computeObjectFeatures(self, timesteps):
         '''
         Return the features per object as nested dictionaries:
         { (int(Timestep), int(Id)):{ "FeatureName" : np.array(value), "NextFeature": ...} }
@@ -113,38 +109,3 @@ class IlastikMergerResolver(hytra.core.mergerresolver.MergerResolver):
             destId = self.resolvedGraph.node[edge[1]]['id']
             value = arcFlowMap[(srcId, destId)]
             self.hypothesesGraph._graph.add_edge(edge[0], edge[1], value=value)
-    
-    def relabelMergers(self, labelImage, time):
-        """
-        Calls the merger resolving plugin to relabel the mergers by fitting a gaussian mixture model.
-        """
-        
-        nextObjectId = labelImage.max() + 1
-        
-        t = str(time)
-        
-        for idx in self.detectionsPerTimestep[t]:
-            node = (time, idx)
-
-            count = 1
-            if idx in self.mergersPerTimestep[t]:
-                count = self.mergersPerTimestep[t][idx]
-            getLogger().debug("Looking at node {} in timestep {} with count {}".format(idx, t, count))
-            
-            # collect initializations from incoming
-            initializations = []
-            for predecessor, _ in self.unresolvedGraph.in_edges(node):
-                initializations.extend(self.unresolvedGraph.node[predecessor]['fits'])
-            # TODO: what shall we do if e.g. a 2-merger and a single object merge to 2 + 1,
-            # so there are 3 initializations for the 2-merger, and two initializations for the 1 merger?
-            # What does pgmlink do in that case?
-
-            # use merger resolving plugin to fit `count` objects, also updates labelimage!
-            fittedObjects = self.mergerResolverPlugin.resolveMerger(labelImage, idx, nextObjectId, count, initializations)
-            assert(len(fittedObjects) == count)
-
-            # split up node if count > 1, duplicate incoming and outgoing arcs
-            if count > 1:
-                nextObjectId += count
-          
-        return labelImage

--- a/hytra/core/ilastikmergerresolver.py
+++ b/hytra/core/ilastikmergerresolver.py
@@ -113,3 +113,38 @@ class IlastikMergerResolver(hytra.core.mergerresolver.MergerResolver):
             destId = self.resolvedGraph.node[edge[1]]['id']
             value = arcFlowMap[(srcId, destId)]
             self.hypothesesGraph._graph.add_edge(edge[0], edge[1], value=value)
+    
+    def relabelMergers(self, labelImage, time):
+        """
+        Calls the merger resolving plugin to relabel the mergers by fitting a gaussian mixture model.
+        """
+        
+        nextObjectId = labelImage.max() + 1
+        
+        t = str(time)
+        
+        for idx in self.detectionsPerTimestep[t]:
+            node = (time, idx)
+
+            count = 1
+            if idx in self.mergersPerTimestep[t]:
+                count = self.mergersPerTimestep[t][idx]
+            getLogger().debug("Looking at node {} in timestep {} with count {}".format(idx, t, count))
+            
+            # collect initializations from incoming
+            initializations = []
+            for predecessor, _ in self.unresolvedGraph.in_edges(node):
+                initializations.extend(self.unresolvedGraph.node[predecessor]['fits'])
+            # TODO: what shall we do if e.g. a 2-merger and a single object merge to 2 + 1,
+            # so there are 3 initializations for the 2-merger, and two initializations for the 1 merger?
+            # What does pgmlink do in that case?
+
+            # use merger resolving plugin to fit `count` objects, also updates labelimage!
+            fittedObjects = self.mergerResolverPlugin.resolveMerger(labelImage, idx, nextObjectId, count, initializations)
+            assert(len(fittedObjects) == count)
+
+            # split up node if count > 1, duplicate incoming and outgoing arcs
+            if count > 1:
+                nextObjectId += count
+          
+        return labelImage

--- a/hytra/core/mergerresolver.py
+++ b/hytra/core/mergerresolver.py
@@ -462,17 +462,14 @@ class MergerResolver(object):
             for idx in self.detectionsPerTimestep[t]:
                 node = (time, idx)
 
-                if idx in self.mergersPerTimestep[t]:
-                    count = self.mergersPerTimestep[t][idx]
-                else:
+                if idx not in self.mergersPerTimestep[t]:
                     continue
-                getLogger().debug("Looking at node {} in timestep {} with count {}".format(idx, t, count))
                 
                 # use fits stored in graph
                 fits = self.unresolvedGraph.node[node]['fits']
                 newIds = self.unresolvedGraph.node[node]['newIds']
                 
-                # use merger resolving plugin to fit `count` objects, also updates labelimage!
+                # use merger resolving plugin to update labelImage with merger IDs
                 self.mergerResolverPlugin.updateLabelImage(labelImage, idx, fits, newIds)
           
         return labelImage

--- a/hytra/pluginsystem/merger_resolver_plugin.py
+++ b/hytra/pluginsystem/merger_resolver_plugin.py
@@ -27,11 +27,18 @@ class MergerResolverPlugin(IPlugin):
         in the preceding frame of all possible incomings (list may be empty, but could
         also be more than `mergerCount`).
 
-        `labelImage` should be updated by replacing all pixels that were labelled with `objectId`
-        to get a new Id depending on the fit, starting from `nextId`.
+        `labelImage` is used read-only, use `updateLabelImage` to refine the segmentation
 
         **returns** a list of fitted objects
         """
         raise NotImplementedError()
 
         return []
+    
+    def updateLabelImage(self, labelImage, objectId, fits, newIds):
+        """
+        Resolve the object with the ID `objectId` in the `labelImage` into the fitted models with the given new IDs.
+        `labelImage` should be updated by replacing all pixels that were labelled with `objectId`
+        to get a new Id depending on the fit.
+        """
+        raise NotImplementedError()


### PR DESCRIPTION
The `relabelMergers()` function was added, and is called from within `opConservationTracking` in Ilastik to request frames with refined merger segmentations.
