### PR TITLE
Added hasNode() function to HypothesesGraph

### DIFF
--- a/hytra/core/hypothesesgraph.py
+++ b/hytra/core/hypothesesgraph.py
@@ -81,6 +81,9 @@ class HypothesesGraph(object):
 
     def countArcs(self):
         return self._graph.number_of_edges()
+    
+    def hasNode(self, node):
+        return self._graph.has_node(node)
 
     @staticmethod
     def source(edge):


### PR DESCRIPTION
Added `hasNode()` function to Hypotheses Graph, since it is used from within `opConservationTracking` in Ilastik.
