### PR TITLE
Spliting Video and Stitching Results

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,6 @@
 # Tracking Toolbox of the IAL Lab @ uni-heidelberg.de
 
-By Carsten Haubold, Steffen Wolf, Letitia Parcalabescu, Bernhard Kausler, Martin Schiegg, and more.
+By Carsten Haubold, Steffen Wolf, Letitia Parcalabescu, Bernhard Kausler, Martin Schiegg, Jaime I. Cervantes and more.
 
 * Build status: [ ![Circle CI](https://circleci.com/gh/chaubold/hytra.png?style=shield&circle-token=27b4fff289dfdb41575cecfab8e865c7cac6a099) ](https://circleci.com/gh/chaubold/hytra)
 * Usage documentation can be found in this [Google document](https://docs.google.com/document/d/1jxkYGlTEUCPqH03pip03eDBBX2pVYEhPGHHvbegHiWw/edit?usp=sharing)

--- a/hytra/core/ilastikmergerresolver.py
+++ b/hytra/core/ilastikmergerresolver.py
@@ -283,7 +283,7 @@ class IlastikMergerResolver(hytra.core.mergerresolver.MergerResolver):
                 traxel.Timestep = n[0]
 
                 traxel.Features = {'com': self._fitToRegionCenter(fit)}
-                self.hypothesesGraph.addNodeFromTraxel(traxel, value=1, mergerValue=True, divisionValue=False)
+                self.hypothesesGraph.addNodeFromTraxel(traxel, value=1, mergerValue=n[1], divisionValue=False)
             
             # remove merger from HG, which also removes all edges that would otherwise be dangling
             self.hypothesesGraph._graph.remove_node(n)

--- a/hytra/core/ilastikmergerresolver.py
+++ b/hytra/core/ilastikmergerresolver.py
@@ -15,8 +15,8 @@ class IlastikMergerResolver(hytra.core.mergerresolver.MergerResolver):
     Specialization of merger resolving to work with the hypotheses graph given by ilastik,
     and to read/write images from/to the input/output slots of the respective operators. 
     '''
-    def __init__(self, hypothesesGraph, pluginPaths=[os.path.abspath('../hytra/plugins')], withFullGraph=False, verbose=False):
-        super(IlastikMergerResolver, self).__init__(pluginPaths, verbose)
+    def __init__(self, hypothesesGraph, pluginPaths=[os.path.abspath('../hytra/plugins')], withFullGraph=False, numSplits=None, verbose=False):
+        super(IlastikMergerResolver, self).__init__(pluginPaths, numSplits, verbose)
         trackingGraph = hypothesesGraph.toTrackingGraph(noFeatures=True)
         self.model = trackingGraph.model
         self.result = hypothesesGraph.getSolutionDictionary()

--- a/hytra/core/jsongraph.py
+++ b/hytra/core/jsongraph.py
@@ -471,4 +471,10 @@ class JsonTrackingGraph(object):
             hypothesesGraph.insertSolution(self.result)
         
         return hypothesesGraph
+    
+    def setTraxelToUniqueId(self, traxelIdPerTimestepToUniqueIdMap):
+        '''
+        Set traxelToUniqueId map.
+        '''
+        self.model['traxelToUniqueId'] = traxelIdPerTimestepToUniqueIdMap
 

--- a/hytra/core/jsonmergerresolver.py
+++ b/hytra/core/jsonmergerresolver.py
@@ -26,7 +26,7 @@ class JsonMergerResolver(hytra.core.mergerresolver.MergerResolver):
                  raw_axes,
                  pluginPaths=[os.path.abspath('../hytra/plugins')],
                  verbose=False):
-        super(JsonMergerResolver, self).__init__(pluginPaths, verbose)
+        super(JsonMergerResolver, self).__init__(pluginPaths, verbose=verbose)
 
         # copy model and result because we will modify it here
         assert(isinstance(jsonTrackingGraph, JsonTrackingGraph))

--- a/hytra/core/mergerresolver.py
+++ b/hytra/core/mergerresolver.py
@@ -8,6 +8,7 @@ from hytra.pluginsystem.plugin_manager import TrackingPluginManager
 import hytra.core.probabilitygenerator as probabilitygenerator
 import hytra.core.jsongraph
 from hytra.core.jsongraph import negLog, listify, JsonTrackingGraph
+from hytra.core.splittracking import SplitTracking
 
 
 def getLogger():
@@ -21,7 +22,7 @@ class MergerResolver(object):
     that handle reading/writing data to the respective sources.
     """
 
-    def __init__(self, pluginPaths=[os.path.abspath('../hytra/plugins')], verbose=False):
+    def __init__(self, pluginPaths=[os.path.abspath('../hytra/plugins')], numSplits=None, verbose=False):
         self.unresolvedGraph = None
         self.resolvedGraph = None
         self.mergersPerTimestep = None
@@ -29,6 +30,7 @@ class MergerResolver(object):
         self.pluginManager = TrackingPluginManager(
             verbose=verbose, pluginPaths=pluginPaths)
         self.mergerResolverPlugin = self.pluginManager.getMergerResolver()
+        self.numSplits = numSplits
 
         # should be filled by constructors of derived classes!
         self.model = None
@@ -201,9 +203,11 @@ class MergerResolver(object):
         trackingGraph = JsonTrackingGraph()
         for node in self.resolvedGraph.nodes_iter():
             additionalFeatures = {}
+            additionalFeatures['nid'] = node
 
             # nodes with no in/out
             numStates = 2
+            
             if len(self.resolvedGraph.in_edges(node)) == 0:
                 # division nodes with no incoming arcs offer 2 units of flow without the need to de-merge
                 if node in self.unresolvedGraph.nodes() and self.unresolvedGraph.node[node]['division'] and len(self.unresolvedGraph.out_edges(node)) == 2:
@@ -241,11 +245,30 @@ class MergerResolver(object):
                 probs = [1.0 - prob, prob]
 
             trackingGraph.addLinkingHypotheses(src, dest, listify(negLog(probs)))
+            
+        # Set TraxelToUniqueId on resolvedGraph's json graph        
+        uuidToTraxelMap = {}
+        traxelIdPerTimestepToUniqueIdMap = {}
+
+        for node in self.resolvedGraph.nodes_iter():
+            uuid = self.resolvedGraph.node[node]['id']
+            uuidToTraxelMap[uuid] = [node]
+
+            for t in uuidToTraxelMap[uuid]:
+                traxelIdPerTimestepToUniqueIdMap.setdefault(str(t[0]), {})[str(t[1])] = uuid
+        
+        trackingGraph.setTraxelToUniqueId(traxelIdPerTimestepToUniqueIdMap)
 
         # track
         import dpct
+        
         weights = {"weights": [1, 1, 1, 1]}
-        mergerResult = dpct.trackMaxFlow(trackingGraph.model, weights)
+        
+        if not self.numSplits:
+            mergerResult = dpct.trackMaxFlow(trackingGraph.model, weights)
+        else:
+            getLogger().info("Running split tracking with {} splits.".format(self.numSplits))
+            mergerResult = SplitTracking.trackFlowBasedWithSplits(trackingGraph.model, weights, numSplits=self.numSplits, withMergerResolver=True)
 
         # transform results to dictionaries that can be indexed by id or (src,dest)
         nodeFlowMap = dict([(int(d['id']), int(d['value'])) for d in mergerResult['detectionResults']])

--- a/hytra/core/splittracking.py
+++ b/hytra/core/splittracking.py
@@ -1,0 +1,256 @@
+'''
+Given a hypotheses graph and weights, this script tries to find split points where there are not many mergers,
+splits the graph into N parts, and tracks them independently.
+'''
+from __future__ import print_function, absolute_import, nested_scopes, generators, division, with_statement, unicode_literals
+import os
+import sys
+sys.path.insert(0, os.path.abspath('..'))
+# standard imports
+try:
+    import commentjson as json
+except ImportError:
+    import json
+import logging
+import copy
+import configargparse as argparse
+import numpy as np
+import networkx as nx
+import hytra.core.jsongraph
+
+def _getLogger():
+    ''' logger to be used in this module '''
+    return logging.getLogger("split-track-stitch")
+
+class SplitTracking:
+    def __init__(self):
+        pass
+     
+    @staticmethod
+    def trackFlowBasedWithSplits(model, weights, numSplits):
+        print('Hello World')
+
+        logging.basicConfig(level=logging.INFO)
+
+        traxelIdPerTimestepToUniqueIdMap, uuidToTraxelMap = hytra.core.jsongraph.getMappingsBetweenUUIDsAndTraxels(model)
+    
+        detectionTimestepTuples = [(timestepIdTuple, entry) for entry in model['segmentationHypotheses'] for timestepIdTuple in uuidToTraxelMap[int(entry['id'])]]
+        detectionsPerTimestep = {}
+        for timestep_id, detection in detectionTimestepTuples:
+            detectionsPerTimestep.setdefault(int(timestep_id[0]), []).append(detection)
+    
+        nonSingletonCostsPerFrame = []
+        detectionsById = {}
+        linksByIdTuple = {}
+    
+        for t in detectionsPerTimestep.keys():
+            nonSingletonCosts = []
+            for d in detectionsPerTimestep[t]:
+                detectionsById[d['id']] = d
+                f = d['features'][:]
+                del f[1]
+                nonSingletonCosts.extend(f)
+            nonSingletonCostsPerFrame.append(min(nonSingletonCosts)[0])
+    
+        for l in model['linkingHypotheses']:
+            linksByIdTuple[(l['src'], l['dest'])] = l
+    
+        # create a list of the sum of 2 neighboring elements (has len = len(nonSingletonCostsPerFrame) - 1)
+        nonSingletonCostsPerFrameGap = [i + j for i, j in zip(nonSingletonCostsPerFrame[:-1], nonSingletonCostsPerFrame[1:])]
+    
+        # for debugging: show which frames could be interesting. The higher the value, the more are all objects in the frame true detections.
+        # import matplotlib.pyplot as plt
+        # plt.figure()
+        # plt.plot(nonSingletonCostsPerFrame)
+        # plt.show()
+    
+        firstFrame = min(detectionsPerTimestep.keys())
+        lastFrame = max(detectionsPerTimestep.keys())
+
+        numFramesPerSplit = (lastFrame - firstFrame) // numSplits
+    
+        # find points where TWO consecutive frames have a low merger score together!
+        # find split points in a range of 10 frames before/after the desired split location
+        # TODO: also consider divisions!
+        splitPoints = []
+        border = 10
+        if numFramesPerSplit < border*2:
+            border = 1
+    
+        for s in range(1, numSplits):
+            desiredSplitPoint = s * numFramesPerSplit
+            subrange = np.array(nonSingletonCostsPerFrameGap[desiredSplitPoint - border : desiredSplitPoint + border])
+            splitPoints.append(desiredSplitPoint - border + np.argmax(subrange))
+    
+        _getLogger().info("Going to split hypotheses graph at frames {}".format(splitPoints))
+    
+        # for debugging: show chosen frames
+        # import matplotlib.pyplot as plt
+        # plt.figure()
+        # plt.plot(nonSingletonCostsPerFrame)
+        # plt.scatter(splitPoints, [nonSingletonCostsPerFrame[s] for s in splitPoints])
+        # plt.show()
+    
+        # split graph
+        def getSubmodel(startTime, endTime):
+            # for each split: take detections from detectionsPerTimestep, store a list of the uuids, then add links by filtering for the uuids
+            # also make sure that appearance/disappearance costs are zero at the beginning/end of each submodel
+    
+            # TODO: tracklets that reach over the gap must be split into two!
+            submodel = {}
+            segmentationHypotheses = []
+            for f in range(startTime, endTime):
+                if f == startTime:
+                    for d in detectionsPerTimestep[f]:
+                        newD = copy.deepcopy(d)
+                        newD['appearanceFeatures'] = [[0.0000001 * sum(range(i+1))] for i in range(len(d['features']))]
+                        segmentationHypotheses.append(newD)
+                elif f+1 == endTime:
+                    for d in detectionsPerTimestep[f]:
+                        newD = copy.deepcopy(d)
+                        newD['disappearanceFeatures'] = [[0.0000001 * sum(range(i+1))] for i in range(len(d['features']))]
+                        segmentationHypotheses.append(newD)
+                else:
+                    segmentationHypotheses.extend(detectionsPerTimestep[f])
+    
+            submodel['segmentationHypotheses'] = segmentationHypotheses
+            uuidsInSubmodel = set([d['id'] for f in range(startTime, endTime) for d in detectionsPerTimestep[f]])
+            submodel['linkingHypotheses'] = [l for l in model['linkingHypotheses'] if (l['src'] in uuidsInSubmodel) and (l['dest'] in uuidsInSubmodel)]
+            submodel['divisionHypotheses'] = []
+            submodel['settings'] = model['settings']
+            return submodel
+    
+        submodels = []
+        lastSplit = 0
+        splitPoints.append(lastFrame) # so that we get the last split as well
+        for splitPoint in splitPoints:
+            _getLogger().info("Creating submodel from t={} to t={}...".format(lastSplit, splitPoint + 1))
+            submodels.append(getSubmodel(lastSplit, splitPoint + 1))
+            _getLogger().info("\t contains {} nodes and {} edges".format(len(submodels[-1]['segmentationHypotheses']), len(submodels[-1]['linkingHypotheses'])))
+            lastSplit = splitPoint + 1
+    
+        # run tracking (in parallel??)
+        results = []
+        import dpct
+        for i, submodel in enumerate(submodels):
+            # TODO: be robust against changes of num weights!
+            # TODO: release GIL in tracking python wrappers to allow parallel solving!!
+            _getLogger().info("Tracking submodel {}/{}".format(i, len(submodels)))
+            results.append(dpct.trackFlowBased(submodel, weights))
+    
+        # merge results
+        # make detection weight higher, or accumulate energy over tracks (but what to do with mergers then?),
+        # or contract everything where source-node, link and destination have the same number of objects?
+        # We choose the last option.
+        _getLogger().info("Setting up model for stitching")
+        tracklets = []
+        links = []
+        stitchingModel = {'segmentationHypotheses': tracklets, 'linkingHypotheses': links, 'divisionHypotheses' : [], 'settings' : model['settings']}
+        nodeIdRemapping = {}
+        valuePerDetection = {}
+    
+        modelIdx = 0
+        for submodel, result in zip(submodels, results):
+            divisionsPerDetection = {}
+            
+            # find connected components of graph where edges are only inserted if the value of the nodes agrees with the value along the link
+            g = nx.Graph()
+            for d in result['detectionResults']:
+                valuePerDetection[d['id']] = d['value']
+                if 'divisionValue' in d and d['divisionValue']:
+                    divisionsPerDetection[d['id']] = True
+                else:
+                    divisionsPerDetection[d['id']] = False
+                g.add_node(d['id'])
+    
+            for l in result['linkingResults']:
+                s, d = l['src'], l['dest']
+                if divisionsPerDetection[s] is False and valuePerDetection[s] == l['value'] and valuePerDetection[d] == l['value']:
+                    g.add_edge(s, d)
+    
+            # for every connected component, insert a node into the stitching graph
+            connectedComponents = nx.connected_components(g)
+            _getLogger().info("Contracting tracks of submodel {}/{}".format(modelIdx, len(submodels)))
+    
+            for c in connectedComponents:
+                # sum over features of dets + links
+                linkFeatures = [link['features'] for idTuple, link in linksByIdTuple.iteritems() if idTuple[0] in c and idTuple[1] in c]
+                detFeatures = [detectionsById[i]['features'] for i in c]
+                accumulatedFeatures = np.sum([hytra.core.jsongraph.delistify(f) for f in linkFeatures + detFeatures], axis=0)
+    
+                trackletId = min(c)
+                contractedNode = {
+                    'id' : trackletId, 
+                    'contains' : c,
+                    'features' : hytra.core.jsongraph.listify(accumulatedFeatures),
+                    'appearanceFeatures' : detectionsById[min(c)]['appearanceFeatures'],
+                    'disappearanceFeatures' : detectionsById[max(c)]['disappearanceFeatures'],
+                }
+                if 'divisionFeatures' in detectionsById[max(c)]:
+                    contractedNode['divisionFeatures'] = detectionsById[max(c)]['divisionFeatures']
+                tracklets.append(contractedNode)
+    
+                for n in c:
+                    nodeIdRemapping[n] = trackletId
+    
+            # add the remaining links to the stitching graph with adjusted source and destination
+            for l in result['linkingResults']:
+                s, d = l['src'], l['dest']
+                if l['value'] > 0 and (valuePerDetection[s] != l['value'] or valuePerDetection[d] != l['value'] or divisionsPerDetection[s]):
+                    newL = {
+                        'src' : nodeIdRemapping[s],
+                        'dest' : nodeIdRemapping[d],
+                        'features' : linksByIdTuple[(s, d)]['features']
+                    }
+    
+                    links.append(newL)
+            modelIdx += 1
+        _getLogger().info("\tgot {} links from within the submodels".format(len(links)))
+    
+        # insert all edges crossing the splits that connect active detections
+        detectionIdsPerTimestep = dict( [(k, [d['id'] for d in v]) for k, v in detectionsPerTimestep.iteritems()])
+        for splitPoint in splitPoints[:-1]:
+            for idTuple, link in linksByIdTuple.iteritems():
+                s, d = idTuple
+                if s in detectionIdsPerTimestep[splitPoint] and d in detectionIdsPerTimestep[splitPoint + 1] and valuePerDetection[s] > 0 and valuePerDetection[d] > 0:
+                    newL = copy.deepcopy(link)
+                    newL['src'] = nodeIdRemapping[s]
+                    newL['dest'] = nodeIdRemapping[d]
+                    links.append(newL)
+    
+        _getLogger().info("\t contains {} nodes and {} edges".format(len(tracklets), len(links)))
+        stitchingResult = dpct.trackFlowBased(stitchingModel, weights)
+        
+        # TODO: extract full result
+        trackletsById = dict([(t['id'], t) for t in tracklets])
+        fullResult = {'detectionResults' : [], 'linkingResults' : [], 'divisionResults' : []}
+        
+        for dr in stitchingResult['detectionResults']:
+            v = dr['value'] 
+            t = trackletsById[dr['id']]
+            if v > 0:
+                for originalUuid in t['contains']:
+                    fullResult['detectionResults'].append({'id': originalUuid, 'value': v})
+                for s, d in linksByIdTuple.keys():
+                    if s in t['contains'] and d in t['contains']:
+                        fullResult['linkingResults'].append({'src': s, 'dest' : d, 'value': v})
+            else:
+                _getLogger().warning("Skipped detection {} while stitching!".format(t))
+    
+        for lr in stitchingResult['linkingResults']:
+            v = lr['value'] 
+            st = trackletsById[lr['src']]
+            dt = trackletsById[lr['dest']]
+            if v > 0:
+                fullResult['linkingResults'].append({'src': max(st['contains']), 'dest' : min(dt['contains']), 'value': v})
+    
+        return fullResult
+
+
+
+
+
+
+
+
+

--- a/hytra/core/splittracking.py
+++ b/hytra/core/splittracking.py
@@ -31,9 +31,9 @@ class SplitTracking:
         pass
      
     @staticmethod
-    def trackFlowBasedWithSplits(model, weights, numSplits=0, numThreads=None, withMergerResolver=None):
+    def trackFlowBasedWithSplits(model, weights, numSplits=None, numThreads=None, withMergerResolver=None):
         # Run tracking on whole video (dont's split) if numSplits is 0
-        if numSplits==0:
+        if numSplits is None:
             _getLogger().info("WARNING: Running flow-based tracking without splits")
             return dpct.trackMaxFlow(model, weights)#dpct.trackFlowBased(model, weights)
         

--- a/hytra/core/splittracking.py
+++ b/hytra/core/splittracking.py
@@ -28,12 +28,10 @@ class SplitTracking:
      
     @staticmethod
     def trackFlowBasedWithSplits(model, weights, numSplits):
-        print('Hello World')
-
         logging.basicConfig(level=logging.INFO)
 
         traxelIdPerTimestepToUniqueIdMap, uuidToTraxelMap = hytra.core.jsongraph.getMappingsBetweenUUIDsAndTraxels(model)
-    
+        
         detectionTimestepTuples = [(timestepIdTuple, entry) for entry in model['segmentationHypotheses'] for timestepIdTuple in uuidToTraxelMap[int(entry['id'])]]
         detectionsPerTimestep = {}
         for timestep_id, detection in detectionTimestepTuples:
@@ -68,6 +66,9 @@ class SplitTracking:
         lastFrame = max(detectionsPerTimestep.keys())
 
         numFramesPerSplit = (lastFrame - firstFrame) // numSplits
+    
+        # Check that number of frames per split is more than 2
+        assert numFramesPerSplit > 2 , "The number of splits is too large; submodel has less than 2 frames"
     
         # find points where TWO consecutive frames have a low merger score together!
         # find split points in a range of 10 frames before/after the desired split location

--- a/hytra/util/hypothesesgraphdiagram.py
+++ b/hytra/util/hypothesesgraphdiagram.py
@@ -6,7 +6,15 @@ import colorsys
 
 
 class HypothesesGraphDiagram(object):
-    def __init__(self, hypothesesGraph, timeRange=(0, 10), width=4000, height=2000, radius=20, withNodeValue=True, withArcValue=True, withArcFeatures=False, withUuid=False, fileName='HypothesesGraph.png', csvFileName=None):         
+    def __init__():
+        pass
+    
+    
+    '''
+    Save json tracking graph diagram for debugging purposes
+    '''
+    @staticmethod
+    def saveJsonGraphDiagram(model, results=None, timeRange=(0, 10), width=4000, height=2000, radius=20, fileName='JsonGraph.png'):
         # Initalize and configure plt plot
         plt.clf()
         fig=plt.figure(1)
@@ -32,7 +40,156 @@ class HypothesesGraphDiagram(object):
                 zorder=10)              
  
         # Get color list
-        colors = self._get_colors(5)
+        def get_colors(num_colors):
+            colors=[]
+            for i in np.arange(0., 360., 360. / num_colors):
+                hue = i/360.
+                lightness = (50 + np.random.rand() * 10)/100.
+                saturation = (90 + np.random.rand() * 10)/100.
+                colors.append(colorsys.hls_to_rgb(hue, lightness, saturation))
+            return colors
+        
+        colors = get_colors(5)
+ 
+        # Get active arcs map
+        # Add code to obtain active arcs in this section
+        
+        if results:
+            # Get result dict by id
+            detResultsByUuid = {}
+            for detection in results['detectionResults']:
+                detResultsByUuid[detection['id']] = detection['value']
+                
+            # Get result dict by id
+            linkResultsByUuid = {}
+            for link in results['linkingResults']:
+                linkResultsByUuid[(link['src'], link['dest'])] = link['value']
+        
+        # Node by uuid 
+        nodeByUuid = {}
+        for node in model['segmentationHypotheses']:
+            uuid = node['id']
+            nodeByUuid[uuid] = node
+         
+        # Draw nodes
+        nodeCoordsMap = {}
+    
+        # Draw nodes 
+        for node in model['segmentationHypotheses']:
+            time = node['nid'][0]
+            id = node['nid'][1]
+            uuid = node['id']
+            
+            # Node is inactive
+            if results and not (uuid in detResultsByUuid and detResultsByUuid[uuid] > 0):
+                continue
+                        
+            # Verify that node is within time ranges and plot nodes
+            if time >= timeRange[0] and time < timeRange[1]:                         
+                nodeCoordsMap[(time, id)] = ( (time-timeRange[0]+1)*columnWidth, id*rowHeight)
+                rowPos[time] += rowHeight
+                 
+                # Set the color of active nodes
+                faceColor = colors[1]
+                nodeLabel = str('')
+                edgeColor = 'k'
+                 
+                # Display label and color from node value                
+                if results:
+                    #faceColor = colors[detResultsByUuid[uuid]] 
+                    nodeLabel = str(detResultsByUuid[uuid])
+                
+                # Set color if node has appearance/disappearance features
+                if 'appearanceFeatures' in node:
+                    faceColor = colors[2] 
+                elif 'disappearanceFeatures' in node:
+                    faceColor = colors[3]
+                    
+                circle=plt.Circle(nodeCoordsMap[(time, id)], radius=radius, edgecolor=edgeColor, facecolor=faceColor, fill=True, zorder=2)
+                ax.add_patch(circle)
+                        
+                ax.annotate(nodeLabel,
+                xy=(0, 0),  
+                xytext=nodeCoordsMap[(time, id)],
+                horizontalalignment='center',
+                verticalalignment='center',
+                zorder=10)           
+         
+        # Draw arcs           
+        for link in model['linkingHypotheses']:
+            uuidSource = link['src']
+            uuidTarget = link['dest']
+            
+            if results and not ((uuidSource, uuidTarget) in linkResultsByUuid and linkResultsByUuid[(uuidSource, uuidTarget)] > 0) :
+                continue
+            
+            nodeSource = nodeByUuid[uuidSource]
+            nodeTarget = nodeByUuid[uuidTarget]
+            
+            sourceNode = nodeSource['nid']
+            targetNode = nodeTarget['nid']
+             
+            sourceTime = sourceNode[0]
+            targetTime = targetNode[0]
+             
+            # Verify that the arc nodes are found within the time range
+            if sourceTime >= timeRange[0] and sourceTime < timeRange[1] and targetTime >= timeRange[0] and targetTime < timeRange[1]:  
+                color = 'k'
+                linestyle = 'solid'
+                linewidth = 1.0               
+ 
+                xArcCoords = [ nodeCoordsMap[sourceNode][0], nodeCoordsMap[targetNode][0] ]
+                yArcCoords = [ nodeCoordsMap[sourceNode][1], nodeCoordsMap[targetNode][1] ]
+ 
+                line=plt.Line2D( xArcCoords, yArcCoords, linewidth=linewidth, color=color, linestyle=linestyle, zorder=1)
+                ax.add_line(line)            
+ 
+        # Save figure
+        plt.axis('off')
+        plt.savefig(fileName)
+        
+        
+
+    '''
+    Save hypotheses graph (networkx digraph) diagram for debugging purposes
+    '''
+    @staticmethod
+    def saveHypothesesGraphDiagram(hypothesesGraph, timeRange=(0, 10), width=4000, height=2000, radius=20, withNodeValue=True, withArcValue=True, withArcFeatures=False, withUuid=False, fileName='HypothesesGraph.png', csvFileName=None):         
+        # Initalize and configure plt plot
+        plt.clf()
+        fig=plt.figure(1)
+        dpi = fig.get_dpi()
+        fig.set_size_inches(width/float(dpi), height/float(dpi))  
+        plt.axis([0,width,0,height])
+        ax=fig.add_subplot(1,1,1)
+         
+        # Compute dimensions
+        columnWidth = width/float(len( range(timeRange[0], timeRange[1]) )+1)
+        rowHeight = 3*radius
+          
+        # Compute row position and add time labels
+        rowPos = {} 
+        for time in range(timeRange[0], timeRange[1]):
+            rowPos[time] = radius*4
+              
+            ax.annotate(str(time),
+                xy=(0, 0),  
+                xytext=((time-timeRange[0]+1)*columnWidth,radius), # fraction, fraction
+                horizontalalignment='center',
+                verticalalignment='center',
+                zorder=10)              
+ 
+        # Get color list
+        def get_colors(num_colors):
+            colors=[]
+            for i in np.arange(0., 360., 360. / num_colors):
+                hue = i/360.
+                lightness = (50 + np.random.rand() * 10)/100.
+                saturation = (90 + np.random.rand() * 10)/100.
+                colors.append(colorsys.hls_to_rgb(hue, lightness, saturation))
+            return colors
+        
+        colors = get_colors(5)
  
         # Get active arcs map
         # Add code to obtain active arcs in this section
@@ -79,16 +236,16 @@ class HypothesesGraphDiagram(object):
         for arc in hypothesesGraph.edges_iter():
             sourceNode = arc[0]
             targetNode = arc[1]
-            
+             
             sourceTime = sourceNode[0]
             targetTime = targetNode[0]
-            
+             
             # Verify that the arc nodes are found within the time range
             if sourceTime >= timeRange[0] and sourceTime < timeRange[1] and targetTime >= timeRange[0] and targetTime < timeRange[1]:  
                 color = 'k'
                 linestyle = 'solid'
                 linewidth = 0.1
-                
+                 
                 if withArcValue and 'value' in hypothesesGraph.edge[sourceNode][targetNode]:
                     linewidth += 1.5*float( hypothesesGraph.edge[sourceNode][targetNode]['value'] )
                     if hypothesesGraph.edge[sourceNode][targetNode]['value'] == 0:
@@ -97,68 +254,18 @@ class HypothesesGraphDiagram(object):
                     linewidth += 10.0*float( hypothesesGraph.edge[sourceNode][targetNode]['features'][0][0] ) 
                 else:
                     linewidth=1.0                 
-
+ 
                 xArcCoords = [ nodeCoordsMap[sourceNode][0], nodeCoordsMap[targetNode][0] ]
                 yArcCoords = [ nodeCoordsMap[sourceNode][1], nodeCoordsMap[targetNode][1] ]
-
+ 
                 line=plt.Line2D( xArcCoords, yArcCoords, linewidth=linewidth, color=color, linestyle=linestyle, zorder=1)
                 ax.add_line(line)  
-
-        # Load node list of a walk from a csv file. The file must contain a 'time' column and a 'id' column
-        if csvFileName: 
-            # Csv file must contain 'time' and 'id' columns      
-            data = np.genfromtxt(csvFileName,delimiter=',', dtype=int, names=True)
-     
-            arcsWeight = {}
             
-            # Generate the arc weights and plot the nodes 
-            for i in range(len(data['time'])-1):
-                sourceNode = (data['time'][i], data['id'][i])
-                targetNode = (data['time'][i+1], data['id'][i+1])
-                
-                sourceTime = sourceNode[0] 
-                targetTime = targetNode[0] 
-                                         
-                if sourceTime >= timeRange[0] and sourceTime < timeRange[1] and  targetTime >= timeRange[0] and targetTime < timeRange[1]:
-                    if targetTime - sourceTime == 1:
-                        arc=(sourceNode,targetNode)
-                        
-                        # Set arc weight based on the number of times that we have walked this path 
-                        if arc in arcsWeight:
-                            arcsWeight[arc] += 0.7
-                        else: 
-                            arcsWeight[arc] = 0.3    
-                    
-                    circle=plt.Circle(nodeCoordsMap[sourceNode], radius=radius, edgecolor='k', facecolor='r', fill=True, zorder=9)
-                    ax.add_patch(circle)
-                     
-            # Plot the arcs     
-            for arc in arcsWeight.keys():        
-                sourceNode = arc[0]
-                targetNode = arc[1]
-                 
-                if sourceNode[0] >= timeRange[0] and sourceNode[0] < timeRange[1] and targetNode[0] >= timeRange[0] and targetNode[0] < timeRange[1]: 
-                    color = 'k'
-                    linestyle = 'solid'
-                    linewidth = arcsWeight[arc]
-                 
-                    coords = [ [nodeCoordsMap[sourceNode][0],nodeCoordsMap[targetNode][0]], [nodeCoordsMap[sourceNode][1],nodeCoordsMap[targetNode][1]] ]
-                 
-                    line=plt.Line2D( coords[0], coords[1], linewidth=linewidth, color=color, linestyle=linestyle, zorder=8)
-                    ax.add_line(line)            
  
         # Save figure
         plt.axis('off')
         plt.savefig(fileName)
 
 
-    # Generate color list
-    def _get_colors(self, num_colors):
-        colors=[]
-        for i in np.arange(0., 360., 360. / num_colors):
-            hue = i/360.
-            lightness = (50 + np.random.rand() * 10)/100.
-            saturation = (90 + np.random.rand() * 10)/100.
-            colors.append(colorsys.hls_to_rgb(hue, lightness, saturation))
-        return colors
+
     


### PR DESCRIPTION
Added the class `SplitTracking` with member function `trackFlowBasedWithSplits()` that splits videos, runs tracking on each sub-section, and stitches the results back together in order to reduce the running-time (useful for long videos). 

Also modified `IlastikMergerResolver`, `MergerResolver` and `JsonGraph` in order to be compatible with split tracking. For now split tracking is still having some problems and has split-tracking disabled by default, but the option is there.

@chaubold could you review the code? The changes are minimal, I only added some parameters that I need on split-tracking. 